### PR TITLE
生产计划物料bug修复，页面跳转正常

### DIFF
--- a/back/src/main/java/com/example/mes/dataAnalysis/Service/Impl/DataAnalysisService.java
+++ b/back/src/main/java/com/example/mes/dataAnalysis/Service/Impl/DataAnalysisService.java
@@ -123,12 +123,18 @@ public class DataAnalysisService implements IDataAnalysisService {
         try {
             HashMap<String,Object> data = new HashMap<>();
             List<MaterialStock> materials = mapper.getMaterialStock(new PageVo(pageOffset,pageSize));
-            for(MaterialStock materialStock:materials){
-                MaterialStock i = mapper.getMaterialInfoByID(materialStock.getMaterial_id());
-                materialStock.setName(i.getName());
+            System.out.println(new PageVo(pageOffset,pageSize));
 
+            for(MaterialStock materialStock:materials){
+
+                MaterialStock i = mapper.getMaterialInfoByID(materialStock.getMaterial_id());
+
+                materialStock.setName(i.getName());
                 materialStock.setSize(i.getSize());
+                System.out.println(materialStock.getMaterial_id());
+                System.out.println(materialStock);
             }
+            System.out.println(materials);
             int count = mapper.getCount();
             data.put("materials",materials);
             data.put("count",count);

--- a/back/src/main/java/com/example/mes/dataAnalysis/Vo/MaterialStock.java
+++ b/back/src/main/java/com/example/mes/dataAnalysis/Vo/MaterialStock.java
@@ -10,10 +10,13 @@ public class MaterialStock {
 
     public MaterialStock() {
     }
-
     public MaterialStock(String material_id, String name, String size, int count) {
         this.material_id = material_id;
         this.name = name;
+        size=size.replace(",", "\",\"");
+        size=size.replace(":", "\":\"");
+        size="{\""+size;
+        size=size+"\"}";
         this.size = size;
 
         this.count = count;


### PR DESCRIPTION
需要在material表中删除编号为10，11，12的三条记录，保留下面的