### PR TITLE
生产计划物料bug修复，页面跳转正常

### DIFF
--- a/back/src/main/java/com/example/mes/dataAnalysis/Service/Impl/DataAnalysisService.java
+++ b/back/src/main/java/com/example/mes/dataAnalysis/Service/Impl/DataAnalysisService.java
@@ -121,6 +121,7 @@ public class DataAnalysisService implements IDataAnalysisService {
     @Override
     public HashMap<String,Object> getMaterialStock(int pageOffset, int pageSize, String company_id) {
         try {
+            System.out.println(company_id);
             HashMap<String,Object> data = new HashMap<>();
             List<MaterialStock> materials = mapper.getMaterialStock(new PageVo(pageOffset,pageSize),company_id);
             for(MaterialStock materialStock:materials){

--- a/back/src/main/java/com/example/mes/dataAnalysis/Vo/MaterialStock.java
+++ b/back/src/main/java/com/example/mes/dataAnalysis/Vo/MaterialStock.java
@@ -15,7 +15,6 @@ public class MaterialStock {
         this.material_id = material_id;
         this.name = name;
         this.size = size;
-
         this.count = count;
     }
 

--- a/back/src/main/resources/mapper/dataAnalysisMapper/DataAnalysisMapper.xml
+++ b/back/src/main/resources/mapper/dataAnalysisMapper/DataAnalysisMapper.xml
@@ -58,7 +58,7 @@
         SELECT m.material_id,ifnull(a.count,0) AS count
         FROM (SELECT goods_id material_id,sum(quantity) AS 'count'
               FROM storage_goods s
-              WHERE s.is_deleted='0' AND types='material' AND (verify='normal' OR verify='delete')
+              WHERE s.is_deleted='0' AND types='material'  AND (verify='normal' OR verify='delete')
               GROUP BY goods_id) AS a RIGHT JOIN material m ON a.material_id=m.material_id
         WHERE m.is_deleted='0' and m.company_id = #{company_id}
         ORDER BY m.material_id ASC

--- a/front/src/views/dataAnalysis/MaterialStock.vue
+++ b/front/src/views/dataAnalysis/MaterialStock.vue
@@ -133,7 +133,7 @@ export default {
           material_id: this.material_id
         }
       }).then(res =>{
-        this.dates =['7-1','7-2','7-3','7-4','7-5','7-6','当前',],
+        this.dates =['7-9','7-10','7-11','7-12','7-13','7-14','当前',],
         this.stocks = res.data.stocks,
         this.drawChart()
       }).catch(err =>{


### PR DESCRIPTION
需要在material表中删除编号为10，11，12的三条记录，保留下面的，控制公司id